### PR TITLE
Return boxed iterators from TransitionSystem methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.12",
  "once_cell",
@@ -560,7 +560,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c8d416a3343cbfc6f4d17bb1cba46b4d7efecb9ee541967763e0b5e04e5fae7"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
  "epaint",
  "nohash-hasher",
 ]
@@ -595,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bb4d3b8bbbd132c99d2a5efec8567e8b6d09b742f758ae6cf1e4b104fe0231"
 dependencies = [
  "ab_glyph",
- "ahash 0.7.7",
+ "ahash 0.7.8",
  "atomic_refcell",
  "emath",
  "nohash-hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "MIT"
 keywords = ["multi-agent", "path-finding", "planning", "robotics"]
 categories = ["algorithms", "science::robotics"]
-exclude = ["resources/*" ]
+exclude = ["resources/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/abstraction/transition.rs
+++ b/src/abstraction/transition.rs
@@ -1,4 +1,4 @@
-use std::{ops::Sub, slice};
+use std::ops::Sub;
 
 use tuple::A2;
 
@@ -19,7 +19,7 @@ where
     C: Ord + LimitValues + Sub<C, Output = DC> + Copy,
 {
     /// Returns the actions that can be applied from the given state.
-    fn actions_from(&self, state: &S) -> slice::Iter<A>;
+    fn actions_from(&self, state: &S) -> Box<dyn Iterator<Item = A> + '_>;
 
     /// Returns the state resulting from applying the given action to the given state.
     fn transition(&self, state: &S, action: &A) -> S;
@@ -28,7 +28,7 @@ where
     fn transition_cost(&self, state: &S, action: &A) -> DC;
 
     /// Returns the actions that can be applied to reach the given state.
-    fn reverse_actions_from(&self, state: &S) -> slice::Iter<A>;
+    fn reverse_actions_from(&self, state: &S) -> Box<dyn Iterator<Item = A> + '_>;
 
     /// Returns the state resulting from applying the given reverse action to the given state.
     fn reverse_transition(&self, state: &S, action: &A) -> S;

--- a/src/search/rra.rs
+++ b/src/search/rra.rs
@@ -153,13 +153,13 @@ where
             for action in self.transition_system.reverse_actions_from(&current.state) {
                 let successor_state = Arc::new(
                     self.transition_system
-                        .reverse_transition(&current.state, action),
+                        .reverse_transition(&current.state, &action),
                 );
 
                 let successor_cost = current.cost
                     + self
                         .transition_system
-                        .reverse_transition_cost(&current.state, action);
+                        .reverse_transition_cost(&current.state, &action);
 
                 let improved = match data.distance.entry(successor_state.clone()) {
                     Occupied(mut e) => {

--- a/src/search/sipp/sipp.rs
+++ b/src/search/sipp/sipp.rs
@@ -262,10 +262,10 @@ where
         {
             let successor_state = self
                 .transition_system
-                .transition(&current.state.internal_state, action);
+                .transition(&current.state.internal_state, &action);
             let transition_cost = self
                 .transition_system
-                .transition_cost(&current.state.internal_state, action);
+                .transition_cost(&current.state.internal_state, &action);
 
             let heuristic = config.heuristic.get_heuristic(&successor_state);
             if heuristic.is_none() {
@@ -395,7 +395,7 @@ where
                 if improved {
                     self.parent.insert(
                         successor.state.clone(),
-                        (Action::new(*action, transition_cost), current.state.clone()),
+                        (Action::new(action, transition_cost), current.state.clone()),
                     );
                     self.queue.push(Reverse(successor))
                 }

--- a/src/world/simple.rs
+++ b/src/world/simple.rs
@@ -90,8 +90,8 @@ impl State for SimpleState {
 }
 
 impl TransitionSystem<SimpleState, GraphEdgeId, MyTime, MyTime> for SimpleWorld {
-    fn actions_from(&self, state: &SimpleState) -> std::slice::Iter<GraphEdgeId> {
-        self.graph.get_edges_out(state.0).iter()
+    fn actions_from(&self, state: &SimpleState) -> Box<dyn Iterator<Item = GraphEdgeId> + '_> {
+        Box::new(self.graph.get_edges_out(state.0).iter().copied())
     }
 
     fn transition(&self, _state: &SimpleState, action: &GraphEdgeId) -> SimpleState {
@@ -102,8 +102,11 @@ impl TransitionSystem<SimpleState, GraphEdgeId, MyTime, MyTime> for SimpleWorld 
         self.time(*action)
     }
 
-    fn reverse_actions_from(&self, state: &SimpleState) -> std::slice::Iter<GraphEdgeId> {
-        self.graph.get_edges_in(state.0).iter()
+    fn reverse_actions_from(
+        &self,
+        state: &SimpleState,
+    ) -> Box<dyn Iterator<Item = GraphEdgeId> + '_> {
+        Box::new(self.graph.get_edges_in(state.0).iter().copied())
     }
 
     fn reverse_transition(&self, _state: &SimpleState, action: &GraphEdgeId) -> SimpleState {


### PR DESCRIPTION
Previously, the TransitionSystem trait was hard-coded to require Slice iterators, which doesn't work if the TransitionSystem is implemented on top of something that's not a Vec.

This PR changes that, and returns Box<dyn Iter> instead, as is more conventional.

In the process, I also bumped the version of one dependency that was causing problems with recent Rust versions.